### PR TITLE
Migrate Database IDs to INT

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/authenticated/IProtectedSchoolProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/authenticated/IProtectedSchoolProcessor.java
@@ -9,7 +9,7 @@ public interface IProtectedSchoolProcessor {
 
   SchoolListResponse getAllSchools(JWTData userData);
 
-  School getSchool(JWTData userData, long schoolId);
+  School getSchool(JWTData userData, int schoolId);
 
   School createSchool(JWTData userdata, NewSchoolRequest newSchoolRequest);
 }

--- a/api/src/main/java/com/codeforcommunity/dto/school/School.java
+++ b/api/src/main/java/com/codeforcommunity/dto/school/School.java
@@ -6,14 +6,14 @@ import java.util.List;
 
 public class School {
 
-  private Long id;
+  private Integer id;
   private String name;
   private String address;
   private Country country;
   private Boolean hidden;
   private List<SchoolContact> contacts;
 
-  public School(Long id, String name, String address, Country country, Boolean hidden) {
+  public School(Integer id, String name, String address, Country country, Boolean hidden) {
     this.id = id;
     this.name = name;
     this.address = address;
@@ -23,7 +23,7 @@ public class School {
   }
 
   public School(
-      Long id,
+      Integer id,
       String name,
       String address,
       Country country,
@@ -37,11 +37,11 @@ public class School {
     this.contacts = contacts;
   }
 
-  public Long getId() {
+  public Integer getId() {
     return id;
   }
 
-  public void setId(Long id) {
+  public void setId(Integer id) {
     this.id = id;
   }
 

--- a/api/src/main/java/com/codeforcommunity/dto/school/SchoolContact.java
+++ b/api/src/main/java/com/codeforcommunity/dto/school/SchoolContact.java
@@ -2,13 +2,13 @@ package com.codeforcommunity.dto.school;
 
 public class SchoolContact {
 
-  private Long id;
+  private Integer id;
   private String name;
   private String email;
   private String address;
   private String phone;
 
-  public SchoolContact(Long id, String name, String email, String address, String phone) {
+  public SchoolContact(Integer id, String name, String email, String address, String phone) {
     this.id = id;
     this.name = name;
     this.email = email;
@@ -16,11 +16,11 @@ public class SchoolContact {
     this.phone = phone;
   }
 
-  public Long getId() {
+  public Integer getId() {
     return id;
   }
 
-  public void setId(Long id) {
+  public void setId(Integer id) {
     this.id = id;
   }
 

--- a/api/src/main/java/com/codeforcommunity/dto/school/SchoolSummary.java
+++ b/api/src/main/java/com/codeforcommunity/dto/school/SchoolSummary.java
@@ -4,21 +4,21 @@ import com.codeforcommunity.enums.Country;
 
 public class SchoolSummary {
 
-  private Long id;
+  private Integer id;
   private String name;
   private Country country;
 
-  public SchoolSummary(Long id, String name, Country country) {
+  public SchoolSummary(Integer id, String name, Country country) {
     this.id = id;
     this.name = name;
     this.country = country;
   }
 
-  public Long getId() {
+  public Integer getId() {
     return id;
   }
 
-  public void setId(Long id) {
+  public void setId(Integer id) {
     this.id = id;
   }
 

--- a/api/src/main/java/com/codeforcommunity/exceptions/UserDoesNotExistException.java
+++ b/api/src/main/java/com/codeforcommunity/exceptions/UserDoesNotExistException.java
@@ -6,7 +6,7 @@ import io.vertx.ext.web.RoutingContext;
 public class UserDoesNotExistException extends HandledException {
   private String identifierMessage;
 
-  public UserDoesNotExistException(long userId) {
+  public UserDoesNotExistException(int userId) {
     this.identifierMessage = "id = " + userId;
   }
 

--- a/api/src/main/java/com/codeforcommunity/rest/RestFunctions.java
+++ b/api/src/main/java/com/codeforcommunity/rest/RestFunctions.java
@@ -66,10 +66,10 @@ public class RestFunctions {
     return Boolean.parseBoolean(paramValue);
   }
 
-  public static long getPathParamAsLong(RoutingContext ctx, String paramName) {
+  public static int getPathParamAsInt(RoutingContext ctx, String paramName) {
     try {
       String paramValue = ctx.pathParam(paramName);
-      return Long.parseLong(paramValue);
+      return Integer.parseInt(paramValue);
     } catch (NumberFormatException ex) {
       throw new MalformedParameterException(paramName);
     }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/authenticated/ProtectedSchoolRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/authenticated/ProtectedSchoolRouter.java
@@ -58,7 +58,7 @@ public class ProtectedSchoolRouter implements IRouter {
   private void handleGetSchoolRoute(RoutingContext ctx) {
     JWTData userData = ctx.get("jwt_data");
 
-    long schoolId = RestFunctions.getPathParamAsLong(ctx, "school_id");
+    int schoolId = RestFunctions.getPathParamAsInt(ctx, "school_id");
     School response = processor.getSchool(userData, schoolId);
 
     end(ctx.response(), 200, JsonObject.mapFrom(response).toString());

--- a/common/src/main/java/com/codeforcommunity/auth/JWTData.java
+++ b/common/src/main/java/com/codeforcommunity/auth/JWTData.java
@@ -4,15 +4,15 @@ import com.codeforcommunity.enums.PrivilegeLevel;
 
 public class JWTData {
 
-  private final Long userId;
+  private final Integer userId;
   private final PrivilegeLevel privilegeLevel;
 
-  public JWTData(Long userId, PrivilegeLevel privilegeLevel) {
+  public JWTData(Integer userId, PrivilegeLevel privilegeLevel) {
     this.userId = userId;
     this.privilegeLevel = privilegeLevel;
   }
 
-  public Long getUserId() {
+  public Integer getUserId() {
     return this.userId;
   }
 

--- a/common/src/main/java/com/codeforcommunity/auth/JWTHandler.java
+++ b/common/src/main/java/com/codeforcommunity/auth/JWTHandler.java
@@ -74,9 +74,9 @@ public class JWTHandler {
   /** Get the stored information in the given jwt string. */
   private JWTData getJWTDataFromToken(String token) {
     DecodedJWT decodedJWT = getDecodedJWT(token);
-    long userId = decodedJWT.getClaim("userId").asLong();
-    PrivilegeLevel privilegeLevel =
-        PrivilegeLevel.from(decodedJWT.getClaim("privilegeLevel").asString());
+    int userId = decodedJWT.getClaim("userId").asInt();
+    String privilegeLevelString = decodedJWT.getClaim("privilegeLevel").asString();
+    PrivilegeLevel privilegeLevel = PrivilegeLevel.from(privilegeLevelString);
     return new JWTData(userId, privilegeLevel);
   }
 

--- a/persist/src/main/resources/db/migration/V1_1__Integer_IDs.sql
+++ b/persist/src/main/resources/db/migration/V1_1__Integer_IDs.sql
@@ -1,0 +1,41 @@
+ALTER TABLE users
+    ALTER COLUMN id TYPE INT;
+
+ALTER TABLE schools
+    ALTER COLUMN id TYPE INT;
+
+ALTER TABLE school_contacts
+    ALTER COLUMN id TYPE INT;
+
+ALTER TABLE school_contacts
+    ALTER COLUMN school_id TYPE INT;
+
+ALTER TABLE school_reports
+    ALTER COLUMN id TYPE INT;
+
+ALTER TABLE school_reports
+    ALTER COLUMN user_id TYPE INT;
+
+ALTER TABLE school_reports
+    ALTER COLUMN school_id TYPE INT;
+
+ALTER TABLE school_reports_with_libraries
+    ALTER COLUMN id TYPE INT;
+
+ALTER TABLE school_reports_with_libraries
+    ALTER COLUMN user_id TYPE INT;
+
+ALTER TABLE school_reports_with_libraries
+    ALTER COLUMN school_id TYPE INT;
+
+ALTER TABLE school_reports_without_libraries
+    ALTER COLUMN id TYPE INT;
+
+ALTER TABLE school_reports_without_libraries
+    ALTER COLUMN user_id TYPE INT;
+
+ALTER TABLE school_reports_without_libraries
+    ALTER COLUMN school_id TYPE INT;
+
+ALTER TABLE verification_keys
+    ALTER COLUMN user_id TYPE INT;

--- a/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
+++ b/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
@@ -70,7 +70,7 @@ public class AuthDatabaseOperations {
    *
    * @throws UserDoesNotExistException if given email does not match a user.
    */
-  public Users getUserPojo(long userId) {
+  public Users getUserPojo(int userId) {
     Optional<Users> maybeUser =
         Optional.ofNullable(
             db.selectFrom(USERS).where(USERS.ID.eq(userId)).fetchOneInto(Users.class));
@@ -185,7 +185,7 @@ public class AuthDatabaseOperations {
    * Given a userId and token, stores the token in the verification_keys table for the user and
    * invalidates all other keys of this type for this user.
    */
-  public String createSecretKey(long userId, VerificationKeyType type) {
+  public String createSecretKey(int userId, VerificationKeyType type) {
 
     // Maybe add a different column besides used?
     db.update(VERIFICATION_KEYS)

--- a/service/src/main/java/com/codeforcommunity/processor/authenticated/ProtectedSchoolProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/authenticated/ProtectedSchoolProcessorImpl.java
@@ -37,7 +37,7 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
   }
 
   @Override
-  public School getSchool(JWTData userData, long schoolId) {
+  public School getSchool(JWTData userData, int schoolId) {
     School school =
         db.select(SCHOOLS.ID, SCHOOLS.NAME, SCHOOLS.ADDRESS, SCHOOLS.COUNTRY, SCHOOLS.HIDDEN)
             .from(SCHOOLS)
@@ -86,7 +86,7 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
       school.setHidden(hidden);
       school.store();
 
-      Long schoolId = school.getId();
+      Integer schoolId = school.getId();
       List<SchoolContact> contacts = this.getSchoolContacts(schoolId);
       return new School(
           school.getId(),
@@ -100,7 +100,7 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     throw new SchoolAlreadyExistsException(name, country);
   }
 
-  private List<SchoolContact> getSchoolContacts(long schoolId) {
+  private List<SchoolContact> getSchoolContacts(int schoolId) {
     return db.select(
             SCHOOL_CONTACTS.ID,
             SCHOOL_CONTACTS.NAME,

--- a/service/src/main/java/com/codeforcommunity/processor/authenticated/ProtectedUserProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/authenticated/ProtectedUserProcessorImpl.java
@@ -32,7 +32,7 @@ public class ProtectedUserProcessorImpl implements IProtectedUserProcessor {
 
   @Override
   public void deleteUser(JWTData userData) {
-    long userId = userData.getUserId();
+    int userId = userData.getUserId();
 
     db.deleteFrom(VERIFICATION_KEYS).where(VERIFICATION_KEYS.USER_ID.eq(userId)).executeAsync();
 
@@ -48,7 +48,7 @@ public class ProtectedUserProcessorImpl implements IProtectedUserProcessor {
 
   @Override
   public void changePassword(JWTData userData, ChangePasswordRequest changePasswordRequest) {
-    long userId = userData.getUserId();
+    int userId = userData.getUserId();
 
     UsersRecord user =
         db.selectFrom(USERS).where(USERS.ID.eq(userId).and(USERS.DELETED_AT.isNull())).fetchOne();


### PR DESCRIPTION
Migrate all `BIGINT` IDs to `INT` to allow consistent use of `Integer` instead of `Long`