### PR TITLE
Update logout to ignore duplicate refresh key

### DIFF
--- a/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
+++ b/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
@@ -16,20 +16,16 @@ import com.codeforcommunity.exceptions.UsedSecretKeyException;
 import com.codeforcommunity.exceptions.UserDoesNotExistException;
 import com.codeforcommunity.processor.unauthenticated.AuthProcessorImpl;
 import com.codeforcommunity.propertiesLoader.PropertiesLoader;
-
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Optional;
-
 import org.jooq.DSLContext;
 import org.jooq.generated.Tables;
 import org.jooq.generated.tables.pojos.Users;
 import org.jooq.generated.tables.records.UsersRecord;
 import org.jooq.generated.tables.records.VerificationKeysRecord;
 
-/**
- * Encapsulates all the database operations that are required for {@link AuthProcessorImpl}.
- */
+/** Encapsulates all the database operations that are required for {@link AuthProcessorImpl}. */
 public class AuthDatabaseOperations {
 
   private final DSLContext db;
@@ -106,7 +102,7 @@ public class AuthDatabaseOperations {
    * with the given values.
    *
    * @throws EmailAlreadyInUseException if the given username and email are already used in the USER
-   *                                    table.
+   *     table.
    */
   public UsersRecord createNewUser(NewUserRequest newUserRequest) {
     String email = newUserRequest.getEmail();
@@ -133,9 +129,7 @@ public class AuthDatabaseOperations {
     return newUser;
   }
 
-  /**
-   * Given a JWT signature, store it in the BLACKLISTED_REFRESHES table.
-   */
+  /** Given a JWT signature, store it in the BLACKLISTED_REFRESHES table. */
   public void addToBlackList(String signature) {
     Timestamp expirationTimestamp = Timestamp.from(Instant.now().plusMillis(msRefreshExpiration));
 
@@ -149,9 +143,7 @@ public class AuthDatabaseOperations {
         .execute();
   }
 
-  /**
-   * Given a JWT signature return true if it is stored in the BLACKLISTED_REFRESHES table.
-   */
+  /** Given a JWT signature return true if it is stored in the BLACKLISTED_REFRESHES table. */
   public boolean isOnBlackList(String signature) {
     return db.fetchExists(
         Tables.BLACKLISTED_REFRESHES.where(
@@ -162,7 +154,7 @@ public class AuthDatabaseOperations {
    * Validates the secret key for the user it was created for and returns the appropriate user.
    *
    * @throws InvalidSecretKeyException if the given token does not exist.
-   * @throws UsedSecretKeyException    if the given token has already been used.
+   * @throws UsedSecretKeyException if the given token has already been used.
    * @throws ExpiredSecretKeyException if the given token is expired.
    */
   public UsersRecord validateSecretKey(String secretKey, VerificationKeyType type) {
@@ -233,9 +225,7 @@ public class AuthDatabaseOperations {
     return tokenResult.getCreatedAt().after(cutoffDate);
   }
 
-  /**
-   * Given a user pojo, return the user's full name.
-   */
+  /** Given a user pojo, return the user's full name. */
   public static String getFullName(Users user) {
     return String.format("%s %s", user.getFirstName(), user.getLastName());
   }

--- a/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
+++ b/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
@@ -16,16 +16,20 @@ import com.codeforcommunity.exceptions.UsedSecretKeyException;
 import com.codeforcommunity.exceptions.UserDoesNotExistException;
 import com.codeforcommunity.processor.unauthenticated.AuthProcessorImpl;
 import com.codeforcommunity.propertiesLoader.PropertiesLoader;
+
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Optional;
+
 import org.jooq.DSLContext;
 import org.jooq.generated.Tables;
 import org.jooq.generated.tables.pojos.Users;
 import org.jooq.generated.tables.records.UsersRecord;
 import org.jooq.generated.tables.records.VerificationKeysRecord;
 
-/** Encapsulates all the database operations that are required for {@link AuthProcessorImpl}. */
+/**
+ * Encapsulates all the database operations that are required for {@link AuthProcessorImpl}.
+ */
 public class AuthDatabaseOperations {
 
   private final DSLContext db;
@@ -102,7 +106,7 @@ public class AuthDatabaseOperations {
    * with the given values.
    *
    * @throws EmailAlreadyInUseException if the given username and email are already used in the USER
-   *     table.
+   *                                    table.
    */
   public UsersRecord createNewUser(NewUserRequest newUserRequest) {
     String email = newUserRequest.getEmail();
@@ -129,19 +133,25 @@ public class AuthDatabaseOperations {
     return newUser;
   }
 
-  /** Given a JWT signature, store it in the BLACKLISTED_REFRESHES table. */
+  /**
+   * Given a JWT signature, store it in the BLACKLISTED_REFRESHES table.
+   */
   public void addToBlackList(String signature) {
     Timestamp expirationTimestamp = Timestamp.from(Instant.now().plusMillis(msRefreshExpiration));
-    db.newRecord(Tables.BLACKLISTED_REFRESHES)
+
+    db.insertInto(Tables.BLACKLISTED_REFRESHES)
         .values(
             signature,
             Timestamp.from(Instant.now()),
             Timestamp.from(Instant.now()),
             expirationTimestamp)
-        .store();
+        .onDuplicateKeyIgnore()
+        .execute();
   }
 
-  /** Given a JWT signature return true if it is stored in the BLACKLISTED_REFRESHES table. */
+  /**
+   * Given a JWT signature return true if it is stored in the BLACKLISTED_REFRESHES table.
+   */
   public boolean isOnBlackList(String signature) {
     return db.fetchExists(
         Tables.BLACKLISTED_REFRESHES.where(
@@ -152,7 +162,7 @@ public class AuthDatabaseOperations {
    * Validates the secret key for the user it was created for and returns the appropriate user.
    *
    * @throws InvalidSecretKeyException if the given token does not exist.
-   * @throws UsedSecretKeyException if the given token has already been used.
+   * @throws UsedSecretKeyException    if the given token has already been used.
    * @throws ExpiredSecretKeyException if the given token is expired.
    */
   public UsersRecord validateSecretKey(String secretKey, VerificationKeyType type) {
@@ -223,7 +233,9 @@ public class AuthDatabaseOperations {
     return tokenResult.getCreatedAt().after(cutoffDate);
   }
 
-  /** Given a user pojo, return the user's full name. */
+  /**
+   * Given a user pojo, return the user's full name.
+   */
   public static String getFullName(Users user) {
     return String.format("%s %s", user.getFirstName(), user.getLastName());
   }


### PR DESCRIPTION
Update the logout out to insert blacklist refresh only if the refresh hash is unique.

This is to fix the following issue:
```
[Hands Across the Sea] [com.codeforcommunity.rest.FailureHandler] Internal server error caused by: SQL [insert into "blacklisted_refreshes" ("refresh_hash", "created_at", "updated_at", "expires") values (?, cast(? as timestamp), cast(? as timestamp), cast(? as timestamp)) returning "blacklisted_refreshes"."refresh_hash"]; ERROR: duplicate key value violates unique constraint "blacklisted_refreshes_pkey"
 Detail: Key (refresh_hash)=(pPmYUbDb07x5VAnJGe1DJiQjHSIk30SZ6pGvroPPEuA) already exists.
com.codeforcommunity.rest.FailureHandler.handleUncaughtError(FailureHandler.java:219)
```