### PR TITLE
Fixed gradesAttended errors and refactored code

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -36,6 +36,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.codeforcommunity</groupId>
+            <artifactId>persist</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
 
     </dependencies>
 

--- a/api/src/main/java/com/codeforcommunity/dto/report/ReportGeneric.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/ReportGeneric.java
@@ -4,6 +4,7 @@ import com.codeforcommunity.enums.Grade;
 import com.codeforcommunity.enums.LibraryStatus;
 import java.sql.Timestamp;
 import java.util.Date;
+import java.util.List;
 
 public class ReportGeneric {
 
@@ -19,7 +20,7 @@ public class ReportGeneric {
   protected String visitReason;
   protected String actionPlan;
   protected String successStories;
-  protected Grade[] gradesAttended;
+  protected List<Grade> gradesAttended;
 
   public ReportGeneric(LibraryStatus libraryStatus) {
     this.libraryStatus = libraryStatus;
@@ -38,7 +39,7 @@ public class ReportGeneric {
       String visitReason,
       String actionPlan,
       String successStories,
-      Grade[] gradesAttended) {
+      List<Grade> gradesAttended) {
     this.id = id;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
@@ -150,11 +151,11 @@ public class ReportGeneric {
     this.successStories = successStories;
   }
 
-  public Grade[] getGradesAttended() {
+  public List<Grade> getGradesAttended() {
     return gradesAttended;
   }
 
-  public void setGradesAttended(Grade[] gradesAttended) {
+  public void setGradesAttended(List<Grade> gradesAttended) {
     this.gradesAttended = gradesAttended;
   }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/report/ReportWithLibrary.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/ReportWithLibrary.java
@@ -6,6 +6,10 @@ import com.codeforcommunity.enums.Grade;
 import com.codeforcommunity.enums.LibraryStatus;
 import com.codeforcommunity.enums.TimeRole;
 import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jooq.generated.tables.records.SchoolReportsWithLibrariesRecord;
 
 public class ReportWithLibrary extends ReportGeneric {
 
@@ -52,7 +56,7 @@ public class ReportWithLibrary extends ReportGeneric {
       String visitReason,
       String actionPlan,
       String successStories,
-      Grade[] gradesAttended) {
+      List<Grade> gradesAttended) {
     super(
         id,
         createdAt,
@@ -80,6 +84,37 @@ public class ReportWithLibrary extends ReportGeneric {
     this.hasSufficientTraining = hasSufficientTraining;
     this.teacherSupport = teacherSupport;
     this.parentSupport = parentSupport;
+  }
+
+  public static ReportWithLibrary instantiateFromRecord(SchoolReportsWithLibrariesRecord record) {
+    return new ReportWithLibrary(
+        record.getId(),
+        record.getCreatedAt(),
+        record.getUpdatedAt(),
+        record.getSchoolId(),
+        record.getUserId(),
+        record.getNumberOfChildren(),
+        record.getNumberOfBooks(),
+        record.getMostRecentShipmentYear(),
+        record.getIsSharedSpace(),
+        record.getHasInvitingSpace(),
+        record.getAssignedPersonRole(),
+        record.getAssignedPersonTitle(),
+        record.getApprenticeshipProgram(),
+        record.getTrainsAndMentorsApprentices(),
+        record.getHasCheckInTimetables(),
+        record.getHasBookCheckoutSystem(),
+        record.getNumberOfStudentLibrarians(),
+        record.getReasonNoStudentLibrarians(),
+        record.getHasSufficientTraining(),
+        record.getTeacherSupport(),
+        record.getParentSupport(),
+        record.getVisitReason(),
+        record.getActionPlan(),
+        record.getSuccessStories(),
+        Arrays.stream(record.getGradesAttended())
+            .map(gradeString -> Grade.valueOf((String) gradeString))
+            .collect(Collectors.toList()));
   }
 
   public Boolean getIsSharedSpace() {

--- a/api/src/main/java/com/codeforcommunity/dto/report/ReportWithoutLibrary.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/ReportWithoutLibrary.java
@@ -4,7 +4,10 @@ import com.codeforcommunity.enums.Grade;
 import com.codeforcommunity.enums.LibraryStatus;
 import com.codeforcommunity.enums.ReadyTimeline;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.jooq.generated.tables.records.SchoolReportsWithoutLibrariesRecord;
 
 public class ReportWithoutLibrary extends ReportGeneric {
 
@@ -35,7 +38,7 @@ public class ReportWithoutLibrary extends ReportGeneric {
       String visitReason,
       String actionPlan,
       String successStories,
-      Grade[] gradesAttended) {
+      List<Grade> gradesAttended) {
     super(
         id,
         createdAt,
@@ -55,6 +58,30 @@ public class ReportWithoutLibrary extends ReportGeneric {
     this.currentStatus = currentStatus;
     this.reason = reason;
     this.readyTimeline = readyTimeline;
+  }
+
+  public static ReportWithoutLibrary instantiateFromRecord(
+      SchoolReportsWithoutLibrariesRecord record) {
+    return new ReportWithoutLibrary(
+        record.getId(),
+        record.getCreatedAt(),
+        record.getUpdatedAt(),
+        record.getSchoolId(),
+        record.getUserId(),
+        record.getNumberOfChildren(),
+        record.getNumberOfBooks(),
+        record.getMostRecentShipmentYear(),
+        record.getWantsLibrary(),
+        record.getHasSpace(),
+        Arrays.asList((String[]) record.getCurrentStatus()),
+        record.getReasonWhyNot(),
+        record.getReadyTimeline(),
+        record.getVisitReason(),
+        record.getActionPlan(),
+        record.getSuccessStories(),
+        Arrays.stream(record.getGradesAttended())
+            .map(gradeString -> Grade.valueOf((String) gradeString))
+            .collect(Collectors.toList()));
   }
 
   public Boolean getWantsLibrary() {

--- a/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportGeneric.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportGeneric.java
@@ -14,7 +14,7 @@ public class UpsertReportGeneric extends ApiDto {
   private String visitReason;
   private String actionPlan;
   private String successStories;
-  private Grade[] gradesAttended;
+  private List<Grade> gradesAttended;
 
   public Integer getNumberOfChildren() {
     return numberOfChildren;
@@ -64,11 +64,11 @@ public class UpsertReportGeneric extends ApiDto {
     this.successStories = successStories;
   }
 
-  public Grade[] getGradesAttended() {
+  public List<Grade> getGradesAttended() {
     return gradesAttended;
   }
 
-  public void setGradesAttended(Grade[] gradesAttended) {
+  public void setGradesAttended(List<Grade> gradesAttended) {
     this.gradesAttended = gradesAttended;
   }
 

--- a/common/src/main/java/com/codeforcommunity/enums/Grade.java
+++ b/common/src/main/java/com/codeforcommunity/enums/Grade.java
@@ -1,59 +1,16 @@
 package com.codeforcommunity.enums;
 
 public enum Grade {
-  KINDERGARTEN("kindergarten"),
-  FIRST_GRADE("first_grade"),
-  SECOND_GRADE("second_grade"),
-  THIRD_GRADE("third_grade"),
-  FOURTH_GRADE("fourth_grade"),
-  FIFTH_GRADE("fifth_grade"),
-  SIXTH_GRADE("sixth_grade"),
-  FORM_ONE("form_one"),
-  FORM_TWO("form_two"),
-  FORM_THREE("form_three"),
-  FORM_FOUR("form_four"),
-  FORM_FIVE("form_five");
-
-  private String name;
-
-  Grade(String name) {
-    this.name = name;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public static Grade from(String name) {
-    for (Grade gradeType : Grade.values()) {
-      if (gradeType.name.equals(name)) {
-        return gradeType;
-      }
-    }
-    throw new IllegalArgumentException(
-        String.format("Given name `%s` doesn't correspond to any `Grade`", name));
-  }
-
-  public static String[] toStringArray(Grade[] gradesAttended) {
-    String[] stringGradesAttended = new String[gradesAttended.length];
-
-    for (int i = 0; i < gradesAttended.length; i++) {
-      stringGradesAttended[i] = gradesAttended[i].toString();
-    }
-
-    return stringGradesAttended;
-  }
-
-  public static Grade[] from(String[] stringGradesAttended) {
-    Grade[] gradesAttended = new Grade[stringGradesAttended.length];
-    for (int i = 0; i < stringGradesAttended.length; i++) {
-      gradesAttended[i] = Grade.from(stringGradesAttended[i]);
-    }
-    return gradesAttended;
-  }
-
-  @Override
-  public String toString() {
-    return this.name;
-  }
+  KINDERGARTEN,
+  FIRST_GRADE,
+  SECOND_GRADE,
+  THIRD_GRADE,
+  FOURTH_GRADE,
+  FIFTH_GRADE,
+  SIXTH_GRADE,
+  FORM_ONE,
+  FORM_TWO,
+  FORM_THREE,
+  FORM_FOUR,
+  FORM_FIVE;
 }

--- a/service/src/main/java/com/codeforcommunity/processor/authenticated/ProtectedSchoolProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/authenticated/ProtectedSchoolProcessorImpl.java
@@ -48,6 +48,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.jooq.DSLContext;
 import org.jooq.generated.tables.records.BookLogsRecord;
 import org.jooq.generated.tables.records.SchoolContactsRecord;
@@ -117,16 +118,8 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     if (school == null) {
       // If the school doesn't already exist, create it
       SchoolsRecord newSchool = db.newRecord(SCHOOLS);
-      newSchool.setName(name);
-      newSchool.setAddress(address);
-      newSchool.setPhone(phone);
-      newSchool.setEmail(email);
-      newSchool.setNotes(notes);
-      newSchool.setArea(area);
-      newSchool.setCountry(country);
-      newSchool.setHidden(hidden);
-      newSchool.setLibraryStatus(libraryStatus);
-      newSchool.store();
+      storeSchool(
+          newSchool, name, address, phone, email, notes, area, country, hidden, libraryStatus);
 
       return new School(
           newSchool.getId(),
@@ -345,6 +338,20 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     Boolean hidden = upsertSchoolRequest.getHidden();
     LibraryStatus libraryStatus = upsertSchoolRequest.getLibraryStatus();
 
+    storeSchool(school, name, address, phone, email, notes, area, country, hidden, libraryStatus);
+  }
+
+  private void storeSchool(
+      SchoolsRecord school,
+      String name,
+      String address,
+      String phone,
+      String email,
+      String notes,
+      String area,
+      Country country,
+      Boolean hidden,
+      LibraryStatus libraryStatus) {
     school.setName(name);
     school.setAddress(address);
     school.setPhone(phone);
@@ -405,41 +412,14 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     school.setLibraryStatus(LibraryStatus.EXISTS);
     school.store();
 
-    if (!isShipmentYearValid(req.getMostRecentShipmentYear())) {
+    if (isShipmentYearInvalid(req.getMostRecentShipmentYear())) {
       throw new InvalidShipmentYearException(req.getMostRecentShipmentYear());
     }
-    String[] stringGradesAttended = Grade.toStringArray(req.getGradesAttended());
 
     // Save a record to the school_reports_with_libraries table
     SchoolReportsWithLibrariesRecord newReport = db.newRecord(SCHOOL_REPORTS_WITH_LIBRARIES);
-    newReport.setUserId(userData.getUserId());
-    newReport.setSchoolId(schoolId);
-    newReport.setNumberOfChildren(req.getNumberOfChildren());
-    newReport.setNumberOfBooks(req.getNumberOfBooks());
-    newReport.setMostRecentShipmentYear(req.getMostRecentShipmentYear());
-    newReport.setIsSharedSpace(req.getIsSharedSpace());
-    newReport.setHasInvitingSpace(req.getHasInvitingSpace());
-    newReport.setAssignedPersonRole(req.getAssignedPersonRole());
-    newReport.setAssignedPersonTitle(req.getAssignedPersonTitle());
-    newReport.setApprenticeshipProgram(req.getApprenticeshipProgram());
-    newReport.setTrainsAndMentorsApprentices(req.getTrainsAndMentorsApprentices());
-    newReport.setHasCheckInTimetables(req.getHasCheckInTimetables());
-    newReport.setHasBookCheckoutSystem(req.getHasBookCheckoutSystem());
-    newReport.setNumberOfStudentLibrarians(req.getNumberOfStudentLibrarians());
-    newReport.setReasonNoStudentLibrarians(req.getReasonNoStudentLibrarians());
-    newReport.setHasSufficientTraining(req.getHasSufficientTraining());
-    newReport.setTeacherSupport(req.getTeacherSupport());
-    newReport.setParentSupport(req.getParentSupport());
-    newReport.setVisitReason(req.getVisitReason());
-    newReport.setActionPlan(req.getActionPlan());
-    newReport.setSuccessStories(req.getSuccessStories());
-    newReport.setGradesAttended(stringGradesAttended);
-
-    // save record and refresh to fetch report ID and timestamps
-    newReport.store();
+    storeReportWithLibrary(userData, schoolId, req, newReport);
     newReport.refresh();
-
-    Grade[] savedGradesAttended = Grade.from(stringGradesAttended);
 
     return new ReportWithLibrary(
         newReport.getId(),
@@ -466,7 +446,7 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
         newReport.getVisitReason(),
         newReport.getActionPlan(),
         newReport.getSuccessStories(),
-        savedGradesAttended);
+        req.getGradesAttended());
   }
 
   @Override
@@ -483,20 +463,26 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
             .where(SCHOOL_REPORTS_WITH_LIBRARIES.ID.eq(reportId))
             .fetchOne();
 
-    if (!userData.isAdmin() && !newReport.getUserId().equals(userData.getUserId())) {
-      throw new AdminOnlyRouteException();
-    }
-
     if (newReport == null) {
       throw new NoReportFoundException(schoolId);
     }
 
-    if (!isShipmentYearValid(req.getMostRecentShipmentYear())) {
+    if (!userData.isAdmin() && !newReport.getUserId().equals(userData.getUserId())) {
+      throw new AdminOnlyRouteException();
+    }
+
+    if (isShipmentYearInvalid(req.getMostRecentShipmentYear())) {
       throw new InvalidShipmentYearException(req.getMostRecentShipmentYear());
     }
 
-    String[] stringGradesAttended = Grade.toStringArray(req.getGradesAttended());
+    storeReportWithLibrary(userData, schoolId, req, newReport);
+  }
 
+  private void storeReportWithLibrary(
+      JWTData userData,
+      int schoolId,
+      UpsertReportWithLibrary req,
+      SchoolReportsWithLibrariesRecord newReport) {
     newReport.setUserId(userData.getUserId());
     newReport.setSchoolId(schoolId);
     newReport.setNumberOfChildren(req.getNumberOfChildren());
@@ -518,7 +504,8 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     newReport.setVisitReason(req.getVisitReason());
     newReport.setActionPlan(req.getActionPlan());
     newReport.setSuccessStories(req.getSuccessStories());
-    newReport.setGradesAttended(stringGradesAttended);
+    newReport.setGradesAttended(
+        (Object[]) req.getGradesAttended().stream().map(Grade::name).toArray(String[]::new));
     newReport.store();
   }
 
@@ -534,20 +521,22 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
 
     if (libraryStatus == LibraryStatus.EXISTS) {
       report =
-          db.selectFrom(SCHOOL_REPORTS_WITH_LIBRARIES)
-              .where(SCHOOL_REPORTS_WITH_LIBRARIES.DELETED_AT.isNull())
-              .and(SCHOOL_REPORTS_WITH_LIBRARIES.SCHOOL_ID.eq(schoolId))
-              .orderBy(SCHOOL_REPORTS_WITH_LIBRARIES.ID.desc())
-              .limit(1)
-              .fetchOneInto(ReportWithLibrary.class);
+          ReportWithLibrary.instantiateFromRecord(
+              db.selectFrom(SCHOOL_REPORTS_WITH_LIBRARIES)
+                  .where(SCHOOL_REPORTS_WITH_LIBRARIES.DELETED_AT.isNull())
+                  .and(SCHOOL_REPORTS_WITH_LIBRARIES.SCHOOL_ID.eq(schoolId))
+                  .orderBy(SCHOOL_REPORTS_WITH_LIBRARIES.ID.desc())
+                  .limit(1)
+                  .fetchOne());
     } else if (libraryStatus == LibraryStatus.DOES_NOT_EXIST) {
       report =
-          db.selectFrom(SCHOOL_REPORTS_WITHOUT_LIBRARIES)
-              .where(SCHOOL_REPORTS_WITHOUT_LIBRARIES.DELETED_AT.isNull())
-              .and(SCHOOL_REPORTS_WITHOUT_LIBRARIES.SCHOOL_ID.eq(schoolId))
-              .orderBy(SCHOOL_REPORTS_WITHOUT_LIBRARIES.ID.desc())
-              .limit(1)
-              .fetchOneInto(ReportWithoutLibrary.class);
+          ReportWithoutLibrary.instantiateFromRecord(
+              db.selectFrom(SCHOOL_REPORTS_WITHOUT_LIBRARIES)
+                  .where(SCHOOL_REPORTS_WITHOUT_LIBRARIES.DELETED_AT.isNull())
+                  .and(SCHOOL_REPORTS_WITHOUT_LIBRARIES.SCHOOL_ID.eq(schoolId))
+                  .orderBy(SCHOOL_REPORTS_WITHOUT_LIBRARIES.ID.desc())
+                  .limit(1)
+                  .fetchOne());
     }
 
     if (report == null) {
@@ -566,20 +555,16 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
       throw new SchoolDoesNotExistException(schoolId);
     }
 
-    if (!isShipmentYearValid(req.getMostRecentShipmentYear())) {
+    if (isShipmentYearInvalid(req.getMostRecentShipmentYear())) {
       throw new InvalidShipmentYearException(req.getMostRecentShipmentYear());
     }
 
     school.setLibraryStatus(LibraryStatus.DOES_NOT_EXIST);
     school.store();
 
-    String[] stringGradesAttended = Grade.toStringArray(req.getGradesAttended());
-
     SchoolReportsWithoutLibrariesRecord newReport = db.newRecord(SCHOOL_REPORTS_WITHOUT_LIBRARIES);
-    storeReportWithoutLibrary(userData, schoolId, req, newReport, stringGradesAttended);
+    storeReportWithoutLibrary(userData, schoolId, req, newReport, req.getGradesAttended());
     newReport.refresh();
-
-    Grade[] savedGradesAttended = Grade.from(stringGradesAttended);
 
     return new ReportWithoutLibrary(
         newReport.getId(),
@@ -598,7 +583,7 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
         newReport.getVisitReason(),
         newReport.getActionPlan(),
         newReport.getSuccessStories(),
-        savedGradesAttended);
+        req.getGradesAttended());
   }
 
   @Override
@@ -616,19 +601,19 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
             .where(SCHOOL_REPORTS_WITHOUT_LIBRARIES.ID.eq(reportId))
             .fetchOne();
 
+    if (newReport == null) {
+      throw new NoReportFoundException(schoolId);
+    }
+
     if (!userData.isAdmin() && !newReport.getUserId().equals(userData.getUserId())) {
       throw new AdminOnlyRouteException();
     }
 
-    if (newReport == null) {
-      throw new NoReportFoundException(schoolId);
-    }
-    if (!isShipmentYearValid(req.getMostRecentShipmentYear())) {
+    if (isShipmentYearInvalid(req.getMostRecentShipmentYear())) {
       throw new InvalidShipmentYearException(req.getMostRecentShipmentYear());
     }
 
-    String[] stringGradesAttended = Grade.toStringArray(req.getGradesAttended());
-    storeReportWithoutLibrary(userData, schoolId, req, newReport, stringGradesAttended);
+    storeReportWithoutLibrary(userData, schoolId, req, newReport, req.getGradesAttended());
   }
 
   private void storeReportWithoutLibrary(
@@ -636,7 +621,7 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
       int schoolId,
       UpsertReportWithoutLibrary req,
       SchoolReportsWithoutLibrariesRecord newReport,
-      Object[] stringGradesAttended) {
+      List<Grade> gradesAttended) {
     newReport.setSchoolId(schoolId);
     newReport.setUserId(userData.getUserId());
     newReport.setNumberOfChildren(req.getNumberOfChildren());
@@ -650,7 +635,8 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     newReport.setVisitReason(req.getVisitReason());
     newReport.setActionPlan(req.getActionPlan());
     newReport.setSuccessStories(req.getSuccessStories());
-    newReport.setGradesAttended(stringGradesAttended);
+    newReport.setGradesAttended(
+        (Object[]) gradesAttended.stream().map(Grade::name).toArray(String[]::new));
     newReport.store();
   }
 
@@ -668,14 +654,16 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     List<ReportWithLibrary> withLibraryReports =
         db.selectFrom(SCHOOL_REPORTS_WITH_LIBRARIES)
             .where(SCHOOL_REPORTS_WITH_LIBRARIES.DELETED_AT.isNull())
-            .and(SCHOOL_REPORTS_WITH_LIBRARIES.SCHOOL_ID.eq(schoolId))
-            .fetchInto(ReportWithLibrary.class);
+            .and(SCHOOL_REPORTS_WITH_LIBRARIES.SCHOOL_ID.eq(schoolId)).fetch().stream()
+            .map(ReportWithLibrary::instantiateFromRecord)
+            .collect(Collectors.toList());
 
     List<ReportWithoutLibrary> noLibraryReports =
         db.selectFrom(SCHOOL_REPORTS_WITHOUT_LIBRARIES)
             .where(SCHOOL_REPORTS_WITHOUT_LIBRARIES.DELETED_AT.isNull())
-            .and(SCHOOL_REPORTS_WITHOUT_LIBRARIES.SCHOOL_ID.eq(schoolId))
-            .fetchInto(ReportWithoutLibrary.class);
+            .and(SCHOOL_REPORTS_WITHOUT_LIBRARIES.SCHOOL_ID.eq(schoolId)).fetch().stream()
+            .map(ReportWithoutLibrary::instantiateFromRecord)
+            .collect(Collectors.toList());
 
     int countWithLibrary =
         db.fetchCount(
@@ -689,7 +677,7 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
                 .where(SCHOOL_REPORTS_WITHOUT_LIBRARIES.DELETED_AT.isNull())
                 .and(SCHOOL_REPORTS_WITHOUT_LIBRARIES.SCHOOL_ID.eq(schoolId)));
 
-    List<ReportGeneric> reports = new ArrayList<ReportGeneric>();
+    List<ReportGeneric> reports = new ArrayList<>();
     reports.addAll(withLibraryReports);
     reports.addAll(noLibraryReports);
     reports.sort(Comparator.comparing(ReportGeneric::getCreatedAt));
@@ -789,14 +777,16 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     List<ReportWithLibrary> withLibraryReports =
         db.selectFrom(SCHOOL_REPORTS_WITH_LIBRARIES)
             .where(SCHOOL_REPORTS_WITH_LIBRARIES.DELETED_AT.isNull())
-            .and(SCHOOL_REPORTS_WITH_LIBRARIES.USER_ID.eq(userData.getUserId()))
-            .fetchInto(ReportWithLibrary.class);
+            .and(SCHOOL_REPORTS_WITH_LIBRARIES.USER_ID.eq(userData.getUserId())).fetch().stream()
+            .map(ReportWithLibrary::instantiateFromRecord)
+            .collect(Collectors.toList());
 
     List<ReportWithoutLibrary> noLibraryReports =
         db.selectFrom(SCHOOL_REPORTS_WITHOUT_LIBRARIES)
             .where(SCHOOL_REPORTS_WITHOUT_LIBRARIES.DELETED_AT.isNull())
-            .and(SCHOOL_REPORTS_WITHOUT_LIBRARIES.USER_ID.eq(userData.getUserId()))
-            .fetchInto(ReportWithoutLibrary.class);
+            .and(SCHOOL_REPORTS_WITHOUT_LIBRARIES.USER_ID.eq(userData.getUserId())).fetch().stream()
+            .map(ReportWithoutLibrary::instantiateFromRecord)
+            .collect(Collectors.toList());
 
     for (ReportWithLibrary report : withLibraryReports) {
       schoolIds.add(report.getSchoolId());
@@ -823,7 +813,11 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
       throw new SchoolDoesNotExistException(schoolId);
     }
 
-    List<BookLog> logs = db.selectFrom(BOOK_LOGS).where(BOOK_LOGS.SCHOOL_ID.eq(schoolId)).and(BOOK_LOGS.DELETED_AT.isNull()).fetchInto(BookLog.class);
+    List<BookLog> logs =
+        db.selectFrom(BOOK_LOGS)
+            .where(BOOK_LOGS.SCHOOL_ID.eq(schoolId))
+            .and(BOOK_LOGS.DELETED_AT.isNull())
+            .fetchInto(BookLog.class);
 
     return (logs != null)
         ? new BookLogListResponse(logs)
@@ -872,7 +866,7 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
         .fetchInto(SchoolContact.class);
   }
 
-  private boolean isShipmentYearValid(Integer year) {
-    return year > 999 && year < 10000;
+  private boolean isShipmentYearInvalid(Integer year) {
+    return year <= 999 || year >= 10000;
   }
 }


### PR DESCRIPTION
Link to story/ticket

### Summary of Pull Request
Fixes bad responses from the backend where the gradesAttended data was just a list of `null`s

### Changes
- Fixed the translation from JOOQ `Object[]` to `List<Grade>`
- Changed the gradesAttended field in DTOs to be `List<Grade>` instead of `Grade[]`
- Refactored processor code to minimize code duplication
- Moved null check to before field access to avoid `NullReferenceException`
- Removed string values associated with `Grade` enum to because its redundant and confusing


### Screenshots / Verification

Creating reports still works:

![image](https://user-images.githubusercontent.com/23691775/125553622-5faea941-e9be-4d52-b858-d92563c08444.png)
![image](https://user-images.githubusercontent.com/23691775/125553632-39ad6043-727d-4bba-b9a2-e7425ec729dc.png)

Getting an individual report shows gradesAttended correctly (not nulls):
![image](https://user-images.githubusercontent.com/23691775/125553674-9e7157b4-7d68-41b7-870e-de337e852a10.png)

Getting multiple reports shows gradesAttended correctly (not nulls):
![image](https://user-images.githubusercontent.com/23691775/125553712-dac679d5-e0e4-4166-a8f2-6f532453256c.png)


Add screenshots or instructions to verify the changes this PR makes works as intended.
