### PR TITLE
Add `timetable` field to ReportWithLibrary

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/report/ReportWithLibrary.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/ReportWithLibrary.java
@@ -5,6 +5,9 @@ import com.codeforcommunity.enums.AssignedPersonTitle;
 import com.codeforcommunity.enums.Grade;
 import com.codeforcommunity.enums.LibraryStatus;
 import com.codeforcommunity.enums.TimeRole;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
@@ -26,6 +29,7 @@ public class ReportWithLibrary extends ReportGeneric {
   private Boolean hasSufficientTraining;
   private String teacherSupport;
   private String parentSupport;
+  private JsonNode timetable;
 
   public ReportWithLibrary() {
     super(LibraryStatus.EXISTS);
@@ -56,7 +60,8 @@ public class ReportWithLibrary extends ReportGeneric {
       String visitReason,
       String actionPlan,
       String successStories,
-      List<Grade> gradesAttended) {
+      List<Grade> gradesAttended,
+      JsonNode timetable) {
     super(
         id,
         createdAt,
@@ -84,6 +89,71 @@ public class ReportWithLibrary extends ReportGeneric {
     this.hasSufficientTraining = hasSufficientTraining;
     this.teacherSupport = teacherSupport;
     this.parentSupport = parentSupport;
+    this.timetable = timetable;
+  }
+
+  public ReportWithLibrary(
+      Integer id,
+      Timestamp createdAt,
+      Timestamp updatedAt,
+      Integer schoolId,
+      Integer userId,
+      Integer numberOfChildren,
+      Integer numberOfBooks,
+      Integer mostRecentShipmentYear,
+      Boolean isSharedSpace,
+      Boolean hasInvitingSpace,
+      TimeRole assignedPersonRole,
+      AssignedPersonTitle assignedPersonTitle,
+      ApprenticeshipProgram apprenticeshipProgram,
+      Boolean trainsAndMentorsApprentices,
+      Boolean hasCheckInTimetables,
+      Boolean hasBookCheckoutSystem,
+      Integer numberOfStudentLibrarians,
+      String reasonNoStudentLibrarians,
+      Boolean hasSufficientTraining,
+      String teacherSupport,
+      String parentSupport,
+      String visitReason,
+      String actionPlan,
+      String successStories,
+      List<Grade> gradesAttended,
+      String timetable) {
+    super(
+        id,
+        createdAt,
+        updatedAt,
+        schoolId,
+        userId,
+        numberOfChildren,
+        numberOfBooks,
+        mostRecentShipmentYear,
+        LibraryStatus.EXISTS,
+        visitReason,
+        actionPlan,
+        successStories,
+        gradesAttended);
+    this.isSharedSpace = isSharedSpace;
+    this.hasInvitingSpace = hasInvitingSpace;
+    this.assignedPersonRole = assignedPersonRole;
+    this.assignedPersonTitle = assignedPersonTitle;
+    this.apprenticeshipProgram = apprenticeshipProgram;
+    this.trainsAndMentorsApprentices = trainsAndMentorsApprentices;
+    this.hasCheckInTimetables = hasCheckInTimetables;
+    this.hasBookCheckoutSystem = hasBookCheckoutSystem;
+    this.numberOfStudentLibrarians = numberOfStudentLibrarians;
+    this.reasonNoStudentLibrarians = reasonNoStudentLibrarians;
+    this.hasSufficientTraining = hasSufficientTraining;
+    this.teacherSupport = teacherSupport;
+    this.parentSupport = parentSupport;
+
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      this.timetable = mapper.readTree(timetable);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          String.format("Failed to parse `timetable` for `ReportWithLibrary` with ID %d", id));
+    }
   }
 
   public static ReportWithLibrary instantiateFromRecord(SchoolReportsWithLibrariesRecord record) {
@@ -114,7 +184,8 @@ public class ReportWithLibrary extends ReportGeneric {
         record.getSuccessStories(),
         Arrays.stream(record.getGradesAttended())
             .map(gradeString -> Grade.valueOf((String) gradeString))
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        record.getTimetable());
   }
 
   public Boolean getIsSharedSpace() {
@@ -219,5 +290,13 @@ public class ReportWithLibrary extends ReportGeneric {
 
   public void setParentSupport(String parentSupport) {
     this.parentSupport = parentSupport;
+  }
+
+  public JsonNode getTimetable() {
+    return timetable;
+  }
+
+  public void setTimetable(JsonNode timetable) {
+    this.timetable = timetable;
   }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportWithLibrary.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportWithLibrary.java
@@ -195,6 +195,12 @@ public class UpsertReportWithLibrary extends UpsertReportGeneric {
       // Validate the "month" field
       if (fieldName.equals("month")) {
         hasMonthField = true;
+        if (!value.isInt()) {
+          logger.error("`UpsertReportWithLibrary` `timetable.month` must be an integer");
+          invalidFields.add("timetable.month");
+          continue;
+        }
+
         int month = value.asInt();
         if (month < 1 || month > 12) {
           logger.error(
@@ -208,6 +214,12 @@ public class UpsertReportWithLibrary extends UpsertReportGeneric {
       // Validate the "year" field
       if (fieldName.equals("year")) {
         hasYearField = true;
+        if (!value.isInt()) {
+          logger.error("`UpsertReportWithLibrary` `timetable.year` must be an integer");
+          invalidFields.add("timetable.year");
+          continue;
+        }
+
         int year = value.asInt();
         if (year < 1900 || year > 2999) {
           logger.error(

--- a/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportWithLibrary.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportWithLibrary.java
@@ -2,11 +2,20 @@ package com.codeforcommunity.dto.report;
 
 import com.codeforcommunity.enums.ApprenticeshipProgram;
 import com.codeforcommunity.enums.AssignedPersonTitle;
+import com.codeforcommunity.enums.Grade;
 import com.codeforcommunity.enums.TimeRole;
 import com.codeforcommunity.exceptions.HandledException;
+import com.codeforcommunity.logger.SLogger;
+import com.codeforcommunity.rest.RestFunctions;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 public class UpsertReportWithLibrary extends UpsertReportGeneric {
+
+  SLogger logger = new SLogger(UpsertReportWithLibrary.class);
 
   private Boolean isSharedSpace;
   private Boolean hasInvitingSpace;
@@ -21,6 +30,15 @@ public class UpsertReportWithLibrary extends UpsertReportGeneric {
   private Boolean hasSufficientTraining;
   private String teacherSupport;
   private String parentSupport;
+  private JsonNode timetable;
+
+  public JsonNode getTimetable() {
+    return timetable;
+  }
+
+  public void JsonNode(JsonNode timetable) {
+    this.timetable = timetable;
+  }
 
   public Boolean getIsSharedSpace() {
     return isSharedSpace;
@@ -152,6 +170,105 @@ public class UpsertReportWithLibrary extends UpsertReportGeneric {
       fields.add("hasSufficientTraining");
     }
 
+    List<String> timetableFields = this.validateTimetable();
+    fields.addAll(timetableFields);
+
     return fields;
+  }
+
+  private List<String> validateTimetable() {
+    List<String> invalidFields = new ArrayList<String>();
+
+    if (this.timetable.isNull()) {
+      return invalidFields;
+    }
+
+    boolean hasMonthField = false;
+    boolean hasYearField = false;
+
+    Iterator<Map.Entry<String, JsonNode>> it = this.timetable.fields();
+    while (it.hasNext()) {
+      Map.Entry<String, JsonNode> entry = it.next();
+      String fieldName = entry.getKey(); // e.g. "firstGrade"
+      JsonNode value = entry.getValue(); // e.g. { "3": 19 }
+
+      // Validate the "month" field
+      if (fieldName.equals("month")) {
+        hasMonthField = true;
+        int month = value.asInt();
+        if (month < 1 || month > 12) {
+          logger.error(
+              String.format(
+                  "`UpsertReportWithLibrary` `timetable` has an invalid field: `%s`", fieldName));
+          invalidFields.add("timetable.month");
+        }
+        continue;
+      }
+
+      // Validate the "year" field
+      if (fieldName.equals("year")) {
+        hasYearField = true;
+        int year = value.asInt();
+        if (year < 1900 || year > 2999) {
+          logger.error(
+              String.format(
+                  "`UpsertReportWithLibrary` `timetable` has an invalid field: `%s`", fieldName));
+          invalidFields.add("timetable.year");
+        }
+        continue;
+      }
+
+      try { // Validate the grade fields
+        String gradeName = RestFunctions.getUpperSnakeFromCamel(fieldName);
+        Grade grade = Grade.valueOf(gradeName);
+
+        // Validate the values of each grade field
+        if (!this.validateTimetableGrade(grade, value)) {
+          invalidFields.add(String.format("timetable.%s", fieldName));
+        }
+      } catch (IllegalArgumentException e) {
+        logger.error(
+            String.format(
+                "`UpsertReportWithLibrary` `timetable` has an invalid field: `%s`", fieldName));
+        invalidFields.add(String.format("timetable.%s", fieldName));
+      }
+    }
+
+    if (!hasYearField) { // "year" is a required field
+      invalidFields.add("timetable.year");
+    }
+    if (!hasMonthField) { // "month" is a required field
+      invalidFields.add("timetable.month");
+    }
+
+    return invalidFields;
+  }
+
+  private boolean validateTimetableGrade(Grade grade, JsonNode timetableGrade) {
+    Iterator<Map.Entry<String, JsonNode>> it = timetableGrade.fields();
+    while (it.hasNext()) {
+      Map.Entry<String, JsonNode> entry = it.next();
+      String dayStr = entry.getKey(); // e.g. "3"
+      JsonNode countNode = entry.getValue(); // e.g. 19
+
+      try {
+        int day = Integer.parseInt(dayStr);
+      } catch (NumberFormatException e) {
+        logger.error(
+            String.format(
+                "`UpsertReportWithLibrary` `timetable.%s` has an invalid date field",
+                grade.toString()));
+        return false;
+      }
+
+      if (!countNode.isInt()) {
+        logger.error(
+            String.format(
+                "`UpsertReportWithLibrary` `timetable.%s` has an invalid count field",
+                grade.toString()));
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/api/src/main/java/com/codeforcommunity/rest/RestFunctions.java
+++ b/api/src/main/java/com/codeforcommunity/rest/RestFunctions.java
@@ -85,6 +85,7 @@ public class RestFunctions {
       throw new UnknownCountryException(countryName);
     }
   }
+
   /**
    * Get's a query parameter that may or may not be there as an optional of the desired type.
    * Attempts to map the query parameter from a string to an instance of the desired type.
@@ -109,5 +110,11 @@ public class RestFunctions {
       returnValue = null;
     }
     return Optional.ofNullable(returnValue);
+  }
+
+  public static String getUpperSnakeFromCamel(String camel) {
+    String regex = "([a-z])([A-Z])";
+    String replacement = "$1_$2";
+    return camel.replaceAll(regex, replacement).toUpperCase();
   }
 }

--- a/persist/src/main/resources/db/migration/V2_2__Report_Timetables.sql
+++ b/persist/src/main/resources/db/migration/V2_2__Report_Timetables.sql
@@ -1,0 +1,2 @@
+ALTER TABLE school_reports_with_libraries
+    ADD COLUMN timetable VARCHAR(768);

--- a/persist/src/main/resources/db/migration/V2_3__Fix_Users.sql
+++ b/persist/src/main/resources/db/migration/V2_3__Fix_Users.sql
@@ -1,0 +1,5 @@
+ALTER TABLE users
+    DROP COLUMN disabled;
+
+ALTER TABLE users
+    ADD COLUMN disabled BOOLEAN NOT NULL DEFAULT FALSE;

--- a/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
+++ b/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
@@ -90,7 +90,12 @@ public class AuthDatabaseOperations {
     Optional<Users> maybeUser =
         Optional.ofNullable(
             db.selectFrom(USERS)
-                .where(USERS.EMAIL.eq(email).and(USERS.DELETED_AT.isNull()).and(USERS.DISABLED.eq(Boolean.FALSE)))
+                .where(
+                    USERS
+                        .EMAIL
+                        .eq(email)
+                        .and(USERS.DELETED_AT.isNull())
+                        .and(USERS.DISABLED.eq(Boolean.FALSE)))
                 .fetchOneInto(Users.class));
 
     return maybeUser

--- a/service/src/main/java/com/codeforcommunity/processor/authenticated/ProtectedSchoolProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/authenticated/ProtectedSchoolProcessorImpl.java
@@ -446,7 +446,8 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
         newReport.getVisitReason(),
         newReport.getActionPlan(),
         newReport.getSuccessStories(),
-        req.getGradesAttended());
+        req.getGradesAttended(),
+        req.getTimetable());
   }
 
   @Override
@@ -506,6 +507,8 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     newReport.setSuccessStories(req.getSuccessStories());
     newReport.setGradesAttended(
         (Object[]) req.getGradesAttended().stream().map(Grade::name).toArray(String[]::new));
+
+    newReport.setTimetable(req.getTimetable().toString());
     newReport.store();
   }
 


### PR DESCRIPTION
_try not to look at the fact that were stringifying a json for this... I did my best to add some nice validation_

 - Fix auth by adding a `DEFAULT FALSE`  to `users.disabled`
 - Add `timetable` field to `UpsertReportWithLibrary`:

```
{
    "visitReason": "Test purpose",
    "numberOfChildren": 5,
    "numberOfBooks": 4,
    "numberOfStudentLibrarians": 0,
    "gradesAttended": [
        "THIRD_GRADE",
        "FORM_TWO",
        "FORM_FIVE"
    ],
    "mostRecentShipmentYear": 2010,
    "hasCheckInTimetables": false,
    "hasBookCheckoutSystem": false,
    "hasSufficientTraining": false,
    "actionPlan": "test",
    "successStories": "test",
    "isSharedSpace": false,
    "hasInvitingSpace": false,
    "assignedPersonRole": "PART_TIME",
    "assignedPersonTitle": "CLASSROOM_TEACHER",
    "apprenticeshipProgram": "NEP",
    "trainsAndMentorsApprentices": false,
    "timetable": {
        "year": 2021,
        "month": 7,
        "kindergarten": {
            "2": 19,
            "16": 12,
            "19": 10
        },
        "firstGrade": {
            "1": 10,
            "3": 30
        }
    }
}
```