### PR TITLE
Updated report with libraries field and made shipment year nullable

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/report/ReportWithLibrary.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/ReportWithLibrary.java
@@ -7,6 +7,7 @@ import com.codeforcommunity.enums.LibraryStatus;
 import com.codeforcommunity.enums.TimeRole;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.json.JsonObject;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Arrays;
@@ -29,7 +30,8 @@ public class ReportWithLibrary extends ReportGeneric {
   private Boolean hasSufficientTraining;
   private String teacherSupport;
   private String parentSupport;
-  private JsonNode timetable;
+  private JsonNode checkInTimetable;
+  private JsonNode checkOutTimetable;
 
   public ReportWithLibrary() {
     super(LibraryStatus.EXISTS);
@@ -61,9 +63,10 @@ public class ReportWithLibrary extends ReportGeneric {
       String actionPlan,
       String successStories,
       List<Grade> gradesAttended,
-      JsonNode timetable,
+      JsonNode checkInTimetable,
       String userName,
-      String schoolName) {
+      String schoolName,
+      JsonNode checkOutTimetable) {
     super(
         id,
         createdAt,
@@ -93,7 +96,8 @@ public class ReportWithLibrary extends ReportGeneric {
     this.hasSufficientTraining = hasSufficientTraining;
     this.teacherSupport = teacherSupport;
     this.parentSupport = parentSupport;
-    this.timetable = timetable;
+    this.checkInTimetable = checkInTimetable;
+    this.checkOutTimetable = checkOutTimetable;
   }
 
   public ReportWithLibrary(
@@ -122,9 +126,10 @@ public class ReportWithLibrary extends ReportGeneric {
       String actionPlan,
       String successStories,
       List<Grade> gradesAttended,
-      String timetable,
+      String checkInTimetable,
       String userName,
-      String schoolName) {
+      String schoolName,
+      String checkOutTimetable) {
     super(
         id,
         createdAt,
@@ -157,10 +162,12 @@ public class ReportWithLibrary extends ReportGeneric {
 
     try {
       ObjectMapper mapper = new ObjectMapper();
-      this.timetable = mapper.readTree(timetable);
+      ObjectMapper checkoutMapper = new ObjectMapper();
+      this.checkInTimetable = mapper.readTree(checkInTimetable);
+      this.checkOutTimetable = checkoutMapper.readTree(checkOutTimetable);
     } catch (IOException e) {
       throw new RuntimeException(
-          String.format("Failed to parse `timetable` for `ReportWithLibrary` with ID %d", id));
+          String.format("Failed to parse timetables for `ReportWithLibrary` with ID %d", id));
     }
   }
 
@@ -194,9 +201,10 @@ public class ReportWithLibrary extends ReportGeneric {
         Arrays.stream(record.getGradesAttended())
             .map(gradeString -> Grade.valueOf((String) gradeString))
             .collect(Collectors.toList()),
-        record.getTimetable(),
+        record.getCheckinTimetable(),
         userName,
-        schoolName);
+        schoolName,
+        record.getCheckoutTimetable());
   }
 
   public Boolean getIsSharedSpace() {
@@ -303,11 +311,17 @@ public class ReportWithLibrary extends ReportGeneric {
     this.parentSupport = parentSupport;
   }
 
-  public JsonNode getTimetable() {
-    return timetable;
+  public JsonNode getCheckInTimetable() {
+    return checkInTimetable;
   }
 
-  public void setTimetable(JsonNode timetable) {
-    this.timetable = timetable;
+  public JsonNode getCheckOutTimetable() { return checkOutTimetable; }
+
+  public void setCheckInTimetable(JsonNode checkInTimetable) {
+    this.checkInTimetable = checkInTimetable;
+  }
+
+  public void setCheckOutTimetable(JsonNode checkOutTimetable) {
+    this.checkOutTimetable = checkOutTimetable;
   }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportGeneric.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportGeneric.java
@@ -81,9 +81,6 @@ public class UpsertReportGeneric extends ApiDto {
     if (numberOfBooks == null) {
       fields.add("numberOfBooks");
     }
-    if (mostRecentShipmentYear == null) {
-      fields.add("mostRecentShipmentYear");
-    }
     if (visitReason == null) {
       fields.add("visitReason");
     }

--- a/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportWithLibrary.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportWithLibrary.java
@@ -30,15 +30,20 @@ public class UpsertReportWithLibrary extends UpsertReportGeneric {
   private Boolean hasSufficientTraining;
   private String teacherSupport;
   private String parentSupport;
-  private JsonNode timetable;
+  private JsonNode checkInTimetable;
+  private JsonNode checkOutTimetable;
 
-  public JsonNode getTimetable() {
-    return timetable;
+  public JsonNode getCheckInTimetable() {
+    return checkInTimetable;
   }
 
-  public void JsonNode(JsonNode timetable) {
-    this.timetable = timetable;
+  public JsonNode getCheckOutTimetable() { return checkOutTimetable; }
+
+  public void JsonNode(JsonNode checkInTimetable) {
+    this.checkInTimetable = checkInTimetable;
   }
+
+  public void setCheckOutTimetable(JsonNode checkOutTimetable) { this.checkOutTimetable = checkOutTimetable; }
 
   public Boolean getIsSharedSpace() {
     return isSharedSpace;
@@ -170,23 +175,24 @@ public class UpsertReportWithLibrary extends UpsertReportGeneric {
       fields.add("hasSufficientTraining");
     }
 
-    List<String> timetableFields = this.validateTimetable();
-    fields.addAll(timetableFields);
-
+    List<String> checkInTimetableFields = this.validateTimetable(checkInTimetable);
+    List<String> checkOutTimetableFields = this.validateTimetable(checkOutTimetable);
+    fields.addAll(checkInTimetableFields);
+    fields.addAll(checkOutTimetableFields);
     return fields;
   }
 
-  private List<String> validateTimetable() {
+  private List<String> validateTimetable(JsonNode timetable) {
     List<String> invalidFields = new ArrayList<String>();
 
-    if (this.timetable.isNull()) {
+    if (timetable.isNull()) {
       return invalidFields;
     }
 
     boolean hasMonthField = false;
     boolean hasYearField = false;
 
-    Iterator<Map.Entry<String, JsonNode>> it = this.timetable.fields();
+    Iterator<Map.Entry<String, JsonNode>> it = timetable.fields();
     while (it.hasNext()) {
       Map.Entry<String, JsonNode> entry = it.next();
       String fieldName = entry.getKey(); // e.g. "firstGrade"
@@ -252,7 +258,6 @@ public class UpsertReportWithLibrary extends UpsertReportGeneric {
     if (!hasMonthField) { // "month" is a required field
       invalidFields.add("timetable.month");
     }
-
     return invalidFields;
   }
 

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/authenticated/ProtectedSchoolRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/authenticated/ProtectedSchoolRouter.java
@@ -303,7 +303,9 @@ public class ProtectedSchoolRouter implements IRouter {
     JWTData userData = ctx.get("jwt_data");
     UpsertReportWithLibrary request =
         RestFunctions.getJsonBodyAsClass(ctx, UpsertReportWithLibrary.class);
+    System.out.println("pt 1");
     int schoolId = RestFunctions.getPathParamAsInt(ctx, "school_id");
+    System.out.println("pt w");
     ReportWithLibrary report = processor.createReportWithLibrary(userData, schoolId, request);
     end(ctx.response(), 201, JsonObject.mapFrom(report).toString());
   }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/authenticated/ProtectedSchoolRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/authenticated/ProtectedSchoolRouter.java
@@ -303,9 +303,7 @@ public class ProtectedSchoolRouter implements IRouter {
     JWTData userData = ctx.get("jwt_data");
     UpsertReportWithLibrary request =
         RestFunctions.getJsonBodyAsClass(ctx, UpsertReportWithLibrary.class);
-    System.out.println("pt 1");
     int schoolId = RestFunctions.getPathParamAsInt(ctx, "school_id");
-    System.out.println("pt w");
     ReportWithLibrary report = processor.createReportWithLibrary(userData, schoolId, request);
     end(ctx.response(), 201, JsonObject.mapFrom(report).toString());
   }

--- a/persist/src/main/resources/db/migration/V2_5__Shipment_Yea_Nullable.sql
+++ b/persist/src/main/resources/db/migration/V2_5__Shipment_Yea_Nullable.sql
@@ -1,0 +1,7 @@
+ALTER TABLE school_reports_with_libraries
+    ALTER COLUMN most_recent_shipment_year
+        DROP NOT NULL;
+
+ALTER TABLE school_reports_without_libraries
+    ALTER COLUMN most_recent_shipment_year
+        DROP NOT NULL;

--- a/persist/src/main/resources/db/migration/V2_6__Checkout_timetable.sql
+++ b/persist/src/main/resources/db/migration/V2_6__Checkout_timetable.sql
@@ -1,0 +1,5 @@
+ALTER TABLE school_reports_with_libraries
+    ADD COLUMN checkout_timetable VARCHAR(768) DEFAULT NULL;
+
+ALTER TABLE school_reports_with_libraries
+    RENAME COLUMN timetable TO checkin_timetable;

--- a/service/src/main/java/com/codeforcommunity/processor/authenticated/ProtectedSchoolProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/authenticated/ProtectedSchoolProcessorImpl.java
@@ -424,9 +424,6 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     school.setLibraryStatus(LibraryStatus.EXISTS);
     school.store();
 
-    if (isShipmentYearInvalid(req.getMostRecentShipmentYear())) {
-      throw new InvalidShipmentYearException(req.getMostRecentShipmentYear());
-    }
 
     // Save a record to the school_reports_with_libraries table
     SchoolReportsWithLibrariesRecord newReport = db.newRecord(SCHOOL_REPORTS_WITH_LIBRARIES);
@@ -459,9 +456,11 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
         newReport.getActionPlan(),
         newReport.getSuccessStories(),
         req.getGradesAttended(),
-        req.getTimetable(),
+        req.getCheckInTimetable(),
         getUserName(userData.getUserId()),
-        getSchoolName(schoolId));
+        getSchoolName(schoolId),
+        req.getCheckOutTimetable()
+        );
   }
 
   @Override
@@ -522,7 +521,8 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     newReport.setGradesAttended(
         (Object[]) req.getGradesAttended().stream().map(Grade::name).toArray(String[]::new));
 
-    newReport.setTimetable(req.getTimetable().toString());
+    newReport.setCheckinTimetable(req.getCheckInTimetable().toString());
+    newReport.setCheckoutTimetable(req.getCheckOutTimetable().toString());
     newReport.store();
   }
 
@@ -911,7 +911,7 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
 
   private String getUserName(int userId) {
     UsersRecord userRecord = db.selectFrom(USERS).where(USERS.ID.eq(userId)).fetchOne();
-    if(userRecord == null){
+    if (userRecord == null) {
       logger.error(String.format("No username found for userId:  %d", userId));
       throw new UserDoesNotExistException(userId);
     }
@@ -920,7 +920,7 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
 
   private String getSchoolName(int schoolId) {
     SchoolsRecord schoolRecord = db.selectFrom(SCHOOLS).where(SCHOOLS.ID.eq(schoolId)).fetchOne();
-    if(schoolRecord == null){
+    if (schoolRecord == null) {
       logger.error(String.format("No school name found for schoolId:  %d", schoolId));
       throw new SchoolDoesNotExistException(schoolId);
     }


### PR DESCRIPTION
Link to story/ticket
https://github.com/orgs/Code-4-Community/projects/3#card-66603908
https://github.com/orgs/Code-4-Community/projects/3#card-65611140
https://github.com/orgs/Code-4-Community/projects/3#card-66603824


### Summary of Pull Request
This PR addresses changes in the ReportWithLibrary class such as field changes, and a brand new field to handle the checkout timetable. It also allows the shipment year to be null for when a shipment year is unavailable.

### Changes
- List the changes this PR makes
- This PR adds the ability for the most recent shipment year to be null by not checking it in the validate fields. 
- Changed the field name from timetable to checkInTimeTable to be more precise and as @maxsebso requested
- Added the checkoutTimeTable field that holds the same logic as checkInTimeTable


### Screenshots / Verification
![Screen Shot 2021-08-17 at 2 20 46 PM](https://user-images.githubusercontent.com/40584532/129779818-11fc33b5-9a79-4232-a305-ae64ef88bb52.png)
![Screen Shot 2021-08-17 at 2 22 00 PM](https://user-images.githubusercontent.com/40584532/129779983-8725e302-acf8-4708-bacd-e9fb306690b4.png)

