### PR TITLE
Jt update report with library DTO and report without library DTO

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/report/ReportWithLibrary.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/ReportWithLibrary.java
@@ -7,7 +7,6 @@ import com.codeforcommunity.enums.LibraryStatus;
 import com.codeforcommunity.enums.TimeRole;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.vertx.core.json.JsonObject;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Arrays;
@@ -32,6 +31,7 @@ public class ReportWithLibrary extends ReportGeneric {
   private String parentSupport;
   private JsonNode checkInTimetable;
   private JsonNode checkOutTimetable;
+  private Integer numberOfStudentLibrariansTrainers;
 
   public ReportWithLibrary() {
     super(LibraryStatus.EXISTS);
@@ -66,7 +66,8 @@ public class ReportWithLibrary extends ReportGeneric {
       JsonNode checkInTimetable,
       String userName,
       String schoolName,
-      JsonNode checkOutTimetable) {
+      JsonNode checkOutTimetable,
+      Integer numberOfStudentLibrariansTrainers) {
     super(
         id,
         createdAt,
@@ -98,6 +99,7 @@ public class ReportWithLibrary extends ReportGeneric {
     this.parentSupport = parentSupport;
     this.checkInTimetable = checkInTimetable;
     this.checkOutTimetable = checkOutTimetable;
+    this.numberOfStudentLibrariansTrainers = numberOfStudentLibrariansTrainers;
   }
 
   public ReportWithLibrary(
@@ -129,7 +131,8 @@ public class ReportWithLibrary extends ReportGeneric {
       String checkInTimetable,
       String userName,
       String schoolName,
-      String checkOutTimetable) {
+      String checkOutTimetable,
+      Integer numberOfStudentLibrariansTrainers) {
     super(
         id,
         createdAt,
@@ -159,6 +162,7 @@ public class ReportWithLibrary extends ReportGeneric {
     this.hasSufficientTraining = hasSufficientTraining;
     this.teacherSupport = teacherSupport;
     this.parentSupport = parentSupport;
+    this.numberOfStudentLibrariansTrainers = numberOfStudentLibrariansTrainers;
 
     try {
       ObjectMapper mapper = new ObjectMapper();
@@ -204,11 +208,16 @@ public class ReportWithLibrary extends ReportGeneric {
         record.getCheckinTimetable(),
         userName,
         schoolName,
-        record.getCheckoutTimetable());
+        record.getCheckoutTimetable(),
+        record.getNumberOfStudentLibrariansTrainers());
   }
 
   public Boolean getIsSharedSpace() {
     return isSharedSpace;
+  }
+
+  public Integer getNumberOfStudentLibrariansTrainers() {
+    return this.numberOfStudentLibrariansTrainers;
   }
 
   public void setIsSharedSpace(Boolean sharedSpace) {
@@ -315,7 +324,9 @@ public class ReportWithLibrary extends ReportGeneric {
     return checkInTimetable;
   }
 
-  public JsonNode getCheckOutTimetable() { return checkOutTimetable; }
+  public JsonNode getCheckOutTimetable() {
+    return checkOutTimetable;
+  }
 
   public void setCheckInTimetable(JsonNode checkInTimetable) {
     this.checkInTimetable = checkInTimetable;
@@ -323,5 +334,9 @@ public class ReportWithLibrary extends ReportGeneric {
 
   public void setCheckOutTimetable(JsonNode checkOutTimetable) {
     this.checkOutTimetable = checkOutTimetable;
+  }
+
+  public void setNumberOfStudentLibrariansTrainers(Integer trainers) {
+    this.numberOfStudentLibrariansTrainers = trainers;
   }
 }

--- a/api/src/main/java/com/codeforcommunity/dto/report/ReportWithoutLibrary.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/ReportWithoutLibrary.java
@@ -16,6 +16,7 @@ public class ReportWithoutLibrary extends ReportGeneric {
   private List<String> currentStatus;
   private String reason;
   private ReadyTimeline readyTimeline;
+  private String reasonNoLibrarySpace;
 
   public ReportWithoutLibrary() {
     super(LibraryStatus.DOES_NOT_EXIST);
@@ -40,7 +41,8 @@ public class ReportWithoutLibrary extends ReportGeneric {
       String successStories,
       List<Grade> gradesAttended,
       String userName,
-      String schoolName) {
+      String schoolName,
+      String reasonNoLibrarySpace) {
     super(
         id,
         createdAt,
@@ -62,6 +64,7 @@ public class ReportWithoutLibrary extends ReportGeneric {
     this.currentStatus = currentStatus;
     this.reason = reason;
     this.readyTimeline = readyTimeline;
+    this.reasonNoLibrarySpace = reasonNoLibrarySpace;
   }
 
   public static ReportWithoutLibrary instantiateFromRecord(
@@ -87,7 +90,8 @@ public class ReportWithoutLibrary extends ReportGeneric {
             .map(gradeString -> Grade.valueOf((String) gradeString))
             .collect(Collectors.toList()),
         userName,
-        schoolName);
+        schoolName,
+        record.getReasonNoLibrarySpace());
   }
 
   public Boolean getWantsLibrary() {
@@ -105,6 +109,8 @@ public class ReportWithoutLibrary extends ReportGeneric {
   public String getReason() {
     return this.reason;
   }
+
+  public String getReasonNoLibrarySpace() { return this.reasonNoLibrarySpace; }
 
   public ReadyTimeline getReadyTimeline() {
     return this.readyTimeline;

--- a/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportWithLibrary.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportWithLibrary.java
@@ -32,18 +32,31 @@ public class UpsertReportWithLibrary extends UpsertReportGeneric {
   private String parentSupport;
   private JsonNode checkInTimetable;
   private JsonNode checkOutTimetable;
+  private Integer numberOfStudentLibrariansTrainers;
 
   public JsonNode getCheckInTimetable() {
     return checkInTimetable;
   }
 
-  public JsonNode getCheckOutTimetable() { return checkOutTimetable; }
+  public JsonNode getCheckOutTimetable() {
+    return checkOutTimetable;
+  }
+
+  public Integer getNumberOfStudentLibrariansTrainers() {
+    return this.numberOfStudentLibrariansTrainers;
+  }
 
   public void JsonNode(JsonNode checkInTimetable) {
     this.checkInTimetable = checkInTimetable;
   }
 
-  public void setCheckOutTimetable(JsonNode checkOutTimetable) { this.checkOutTimetable = checkOutTimetable; }
+  public void setCheckOutTimetable(JsonNode checkOutTimetable) {
+    this.checkOutTimetable = checkOutTimetable;
+  }
+
+  public void setNumberOfStudentLibrariansTrainers(Integer trainers) {
+    this.numberOfStudentLibrariansTrainers = trainers;
+  }
 
   public Boolean getIsSharedSpace() {
     return isSharedSpace;

--- a/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportWithoutLibrary.java
+++ b/api/src/main/java/com/codeforcommunity/dto/report/UpsertReportWithoutLibrary.java
@@ -10,10 +10,13 @@ public class UpsertReportWithoutLibrary extends UpsertReportGeneric {
   private Boolean hasSpace;
   private List<String> currentStatus;
   private ReadyTimeline readyTimeline;
+  private String reasonNoLibrarySpace;
 
   public String getReason() {
     return reason;
   }
+
+  public String getReasonNoLibrarySpace() { return this.reasonNoLibrarySpace; }
 
   public void setReason(String reason) {
     this.reason = reason;

--- a/persist/src/main/resources/db/migration/V2_7__Add_Trainers_Library_Prevention.sql
+++ b/persist/src/main/resources/db/migration/V2_7__Add_Trainers_Library_Prevention.sql
@@ -1,0 +1,2 @@
+ALTER TABLE school_reports_with_libraries
+    ADD COLUMN number_of_student_librarians_trainers INTEGER DEFAULT NULL;

--- a/persist/src/main/resources/db/migration/V2_8__Add_Reason_No_Library_Space.sql
+++ b/persist/src/main/resources/db/migration/V2_8__Add_Reason_No_Library_Space.sql
@@ -1,0 +1,2 @@
+ALTER TABLE school_reports_without_libraries
+    ADD COLUMN reason_no_library_space VARCHAR(768) DEFAULT NULL;

--- a/service/src/main/java/com/codeforcommunity/processor/authenticated/ProtectedSchoolProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/authenticated/ProtectedSchoolProcessorImpl.java
@@ -424,7 +424,6 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     school.setLibraryStatus(LibraryStatus.EXISTS);
     school.store();
 
-
     // Save a record to the school_reports_with_libraries table
     SchoolReportsWithLibrariesRecord newReport = db.newRecord(SCHOOL_REPORTS_WITH_LIBRARIES);
     storeReportWithLibrary(userData, schoolId, req, newReport);
@@ -459,8 +458,8 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
         req.getCheckInTimetable(),
         getUserName(userData.getUserId()),
         getSchoolName(schoolId),
-        req.getCheckOutTimetable()
-        );
+        req.getCheckOutTimetable(),
+        req.getNumberOfStudentLibrariansTrainers());
   }
 
   @Override
@@ -523,6 +522,7 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
 
     newReport.setCheckinTimetable(req.getCheckInTimetable().toString());
     newReport.setCheckoutTimetable(req.getCheckOutTimetable().toString());
+    newReport.setNumberOfStudentLibrariansTrainers(req.getNumberOfStudentLibrariansTrainers());
     newReport.store();
   }
 
@@ -606,7 +606,9 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
         newReport.getSuccessStories(),
         req.getGradesAttended(),
         getUserName(userData.getUserId()),
-        getSchoolName(schoolId));
+        getSchoolName(schoolId),
+        newReport.getReasonNoLibrarySpace()
+        );
   }
 
   @Override
@@ -660,6 +662,7 @@ public class ProtectedSchoolProcessorImpl implements IProtectedSchoolProcessor {
     newReport.setSuccessStories(req.getSuccessStories());
     newReport.setGradesAttended(
         (Object[]) gradesAttended.stream().map(Grade::name).toArray(String[]::new));
+    newReport.setReasonNoLibrarySpace(req.getReasonNoLibrarySpace());
     newReport.store();
   }
 


### PR DESCRIPTION
Link to story/ticket
https://github.com/Code-4-Community/hands-across-the-sea-backend/issues/66
https://github.com/Code-4-Community/hands-across-the-sea-backend/issues/63

### Summary of Pull Request
This PR addresses the backend portion of having the follow up field for not having a library space and the field for number of student librarian trainers. It updates the DTO's for both ReportWithLibrary and ReportWithoutLibrary.

### Changes
- Adds ```reasonNoLibrarySpace``` to ```ReportWithoutLibrary``` DTO.
- Adds ```numberOfStudentLibrariansTrainers ``` to ```ReportWithLibrary``` DTO.
- Updates processor implementation to add these fields fro saving in the database.


### Screenshots / Verification
<img width="1006" alt="Screen Shot 2021-08-24 at 3 31 49 PM" src="https://user-images.githubusercontent.com/40584532/130678372-0755bc62-1726-4973-8ffc-0d50487c9780.png">
<img width="1003" alt="Screen Shot 2021-08-24 at 3 32 32 PM" src="https://user-images.githubusercontent.com/40584532/130678462-b175402c-3969-4de0-bc92-95083886c20a.png">

